### PR TITLE
security: fix 5 vulnerabilities (1c/4h) [20260518]

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -32,7 +32,7 @@
         "@leafygreen-ui/tooltip": "^13.0.9",
         "@leafygreen-ui/typography": "^20.1.3",
         "mongodb": "^6.14.2",
-        "next": "^15.4.10",
+        "next": "^15.5.16",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -3836,9 +3836,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.4.10",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.10.tgz",
-      "integrity": "sha512-knhmoJ0Vv7VRf6pZEPSnciUG1S4bIhWx+qTYBW/AjxEtlzsiNORPk8sFDCEvqLfmKuey56UB9FL1UdHEV3uBrg==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.16.tgz",
+      "integrity": "sha512-9QMKolCl+JnJtaRAQSXy4RQrhgfe8W7/G1+Hl3QSB/HZY7zQMzTwPDdTRwwio8BS96ps1MHpHhbS8qxoNV3JIQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -3852,9 +3852,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.8.tgz",
-      "integrity": "sha512-Pf6zXp7yyQEn7sqMxur6+kYcywx5up1J849psyET7/8pG2gQTVMjU3NzgIt8SeEP5to3If/SaWmaA6H6ysBr1A==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.16.tgz",
+      "integrity": "sha512-wzdER4JZj+31vNkhaZ1Ght3IsNI8DMwj7VqadfIOqJB5sh8FiOqNSopYADQn6mgEPomzDd/DHqBcfo2fmVMYtg==",
       "cpu": [
         "arm64"
       ],
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.8.tgz",
-      "integrity": "sha512-xla6AOfz68a6kq3gRQccWEvFC/VRGJmA/QuSLENSO7CZX5WIEkSz7r1FdXUjtGCQ1c2M+ndUAH7opdfLK1PQbw==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.16.tgz",
+      "integrity": "sha512-PPTo+cvcanxkuDEuDyZGk28ntmu0WjfkxqlG7hw9Mhsiribs4x1C6h2Culn0cJKqsne1gFjjZRK3ax7WYlSxgg==",
       "cpu": [
         "x64"
       ],
@@ -3884,11 +3884,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.8.tgz",
-      "integrity": "sha512-y3fmp+1Px/SJD+5ntve5QLZnGLycsxsVPkTzAc3zUiXYSOlTPqT8ynfmt6tt4fSo1tAhDPmryXpYKEAcoAPDJw==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.16.tgz",
+      "integrity": "sha512-Jl0IL9P7S8uNl5oI1TqrQmfmLp7OqjWM58000pVnUVIsHrvPP6m9QDW/uNWYUbmd+8IYvc6MTeZKICstBMBpew==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3900,11 +3903,14 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.8.tgz",
-      "integrity": "sha512-DX/L8VHzrr1CfwaVjBQr3GWCqNNFgyWJbeQ10Lx/phzbQo3JNAxUok1DZ8JHRGcL6PgMRgj6HylnLNndxn4Z6A==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.16.tgz",
+      "integrity": "sha512-Zf0BIqv/o5uOWfyRkzgGhyV2Tky7HLt0bG+w7XWdaU1JpyX0tltM3TrSfa/Y9c597SJG4CzN47+u2InhgZZ4vg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3916,11 +3922,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.8.tgz",
-      "integrity": "sha512-9fLAAXKAL3xEIFdKdzG5rUSvSiZTLLTCc6JKq1z04DR4zY7DbAPcRvNm3K1inVhTiQCs19ZRAgUerHiVKMZZIA==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.16.tgz",
+      "integrity": "sha512-HCDDU1TRLeUDV180QQTWrs5Oa4lIcI7XH9nF0UVUVmYLN/boZ6LqyFtm3814gc1fv+lOVyKaw5B6bVC9BpXTSQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -3932,11 +3941,14 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.8.tgz",
-      "integrity": "sha512-s45V7nfb5g7dbS7JK6XZDcapicVrMMvX2uYgOHP16QuKH/JA285oy6HcxlKqwUNaFY/UC6EvQ8QZUOo19cBKSA==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.16.tgz",
+      "integrity": "sha512-kvXUY1dn5wxKuMkXxQRUbPjEnKxW1PR9uKOm0zpIpj3574+cFfaePhYFmBVtrOuwt+w34OdDzNaJr5Iixf+HBQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3948,9 +3960,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.8.tgz",
-      "integrity": "sha512-KjgeQyOAq7t/HzAJcWPGA8X+4WY03uSCZ2Ekk98S9OgCFsb6lfBE3dbUzUuEQAN2THbwYgFfxX2yFTCMm8Kehw==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.16.tgz",
+      "integrity": "sha512-zpOQuF+eyENMXRjglp2hZCIrUjTdO37suEBnDn1mX4PXSuetXZDMLpjKOh4dYSw3SiDTnOoOUwBl5i5Elr6nnQ==",
       "cpu": [
         "arm64"
       ],
@@ -3964,9 +3976,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.4.8",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.8.tgz",
-      "integrity": "sha512-Exsmf/+42fWVnLMaZHzshukTBxZrSwuuLKFvqhGHJ+mC1AokqieLY/XzAl3jc/CqhXLqLY3RRjkKJ9YnLPcRWg==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.16.tgz",
+      "integrity": "sha512-LnwKYpiSmIzXlTq76hMeeIzZoDcFwu848p6H+QBkGFJIbZphgzNUPdHruJcHM/bFnaFeco0l1Frie5I27VKglA==",
       "cpu": [
         "x64"
       ],
@@ -6643,17 +6655,13 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.4.tgz",
+      "integrity": "sha512-jE8ugADnYOBsu1uaoayVl1tVKAMNOXyjwvv2U6udEA2ORBhDooJDWoGxTkhd4Qn4yh59JVVt/pKXtjPwx9OguQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
@@ -6738,9 +6746,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7885,9 +7893,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.0.tgz",
+      "integrity": "sha512-l1mfj2atMqndAHI3ls7XqPxEjV2J9ZkcNyHpoZA3r2T1LLwDB69jgkMWh71YKwhBbK0G2f4WSn05ahmQXVxupA==",
+      "deprecated": "Bad release. Please use lodash@4.17.21 instead.",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -7964,9 +7973,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8096,12 +8105,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.4.10",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.4.10.tgz",
-      "integrity": "sha512-itVlc79QjpKMFMRhP+kbGKaSG/gZM6RCvwhEbwmCNF06CdDiNaoHcbeg0PqkEa2GOcn8KJ0nnc7+yL7EjoYLHQ==",
+      "version": "15.5.16",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.16.tgz",
+      "integrity": "sha512-aZExBk/V6JCu3NCFc90twdj9L/M3y0+ukeQwUAZbOiqRhAX+h2oMEa0NZFhcpj6HYRYjVS3V2/3xvyOpNnmw7A==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.4.10",
+        "@next/env": "15.5.16",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -8114,14 +8123,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.4.8",
-        "@next/swc-darwin-x64": "15.4.8",
-        "@next/swc-linux-arm64-gnu": "15.4.8",
-        "@next/swc-linux-arm64-musl": "15.4.8",
-        "@next/swc-linux-x64-gnu": "15.4.8",
-        "@next/swc-linux-x64-musl": "15.4.8",
-        "@next/swc-win32-arm64-msvc": "15.4.8",
-        "@next/swc-win32-x64-msvc": "15.4.8",
+        "@next/swc-darwin-arm64": "15.5.16",
+        "@next/swc-darwin-x64": "15.5.16",
+        "@next/swc-linux-arm64-gnu": "15.5.16",
+        "@next/swc-linux-arm64-musl": "15.5.16",
+        "@next/swc-linux-x64-gnu": "15.5.16",
+        "@next/swc-linux-x64-musl": "15.5.16",
+        "@next/swc-win32-arm64-msvc": "15.5.16",
+        "@next/swc-win32-x64-msvc": "15.5.16",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,7 @@
     "@leafygreen-ui/tooltip": "^13.0.9",
     "@leafygreen-ui/typography": "^20.1.3",
     "mongodb": "^6.14.2",
-    "next": "^15.4.10",
+    "next": "^15.5.16",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -42,5 +42,11 @@
     "eslint": "^9",
     "eslint-config-next": "15.2.1",
     "license-checker": "^25.0.1"
+  },
+  "overrides": {
+    "fast-xml-parser": "4.5.4",
+    "lodash": "4.18.0",
+    "flatted": "3.4.2",
+    "minimatch": "3.1.3"
   }
 }


### PR DESCRIPTION
## Security Fix Bundle — 20260518

Fixes **5 Dependabot alert(s)** (1 critical, 4 high).

| Package | Severity | CVE/GHSA | Fixed Version | Manifest |
|---------|----------|----------|---------------|---------|
| fast-xml-parser | critical | CVE-2026-25896 | 4.5.4 | `app/package-lock.json` |
| next | high | CVE-2026-44573 | 15.5.16 | `app/package-lock.json` |
| lodash | high | CVE-2026-4800 | 4.18.0 | `app/package-lock.json` |
| flatted | high | CVE-2026-33228 | 3.4.2 | `app/package-lock.json` |
| minimatch | high | CVE-2026-27903 | 3.1.3 | `app/package-lock.json` |

> Auto-generated by security_fix.py on 20260518
> Dependabot alerts: #32, #66, #52, #41, #35
